### PR TITLE
Add support for RethinkDB's auth key

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -29,10 +29,11 @@ class Connection extends \Illuminate\Database\Connection {
         $this->database = $config['database'];
 
         $port = isset($config['port']) ? $config['port'] : 28015;
+        $authKey = isset($config['authKey']) ? $config['authKey'] : null;
 
         // Create the connection
         $this->connection = r\connect($config['host'],
-            $port, $this->database);
+            $port, $this->database, $authKey);
     }
 
     /**


### PR DESCRIPTION
Adds a new configuration array item (`authKey`) and passes it into php-rql.
