### PR TITLE
Removing toNative

### DIFF
--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -28,7 +28,7 @@ class Builder extends \Illuminate\Database\Schema\Builder
     {
         $conn = $this->connection->getConnection();
         $db = r\db($this->connection->getDatabaseName());
-        $tables = $db->tableList()->run($conn)->toNative();
+        $tables = $db->tableList()->run($conn);
 
         return in_array($table, $tables);
     }


### PR DESCRIPTION
Starting with PHP-RQL 2.0, toNative() is no longer necessary. Instead run() and cursors will return native objects directly (similar to the official drivers).

@see https://github.com/danielmewes/php-rql/issues/77
