### PR TITLE
Removing toNative()

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -84,7 +84,7 @@ class Builder extends QueryBuilder
             $this->query->pluck($columns);
         }
 
-        $results = $this->query->run()->toNative();
+        $results = $this->query->run();
 
         if (isset($results['$reql_type$'])
             && $results['$reql_type$'] === 'GROUPED_DATA')
@@ -175,7 +175,7 @@ class Builder extends QueryBuilder
     protected function performUpdate($query, array $options = array())
     {
         $this->compileWheres();
-        $result = $this->query->update($query)->run()->toNative();
+        $result = $this->query->update($query)->run();
 
         if (0 == (int)$result['errors']) {
             return $result['replaced'];
@@ -199,7 +199,7 @@ class Builder extends QueryBuilder
             $this->where('id', '=', $id);
         }
         $this->compileWheres();
-        return $this->query->delete()->run()->toNative();
+        return $this->query->delete()->run();
     }
 
     /**
@@ -234,7 +234,7 @@ class Builder extends QueryBuilder
      */
     public function truncate()
     {
-        $result = $this->query->delete()->run()->toNative();
+        $result = $this->query->delete()->run();
         return (0 == (int) $result['errors']);
     }
 
@@ -253,7 +253,7 @@ class Builder extends QueryBuilder
         $this->compileWheres();
         $result = $this->query->update([
             $column => r\row($column)->{$operation}($value)
-        ])->run()->toNative();
+        ])->run();
 
         return (0 == (int) $result['errors']);
     }
@@ -270,7 +270,7 @@ class Builder extends QueryBuilder
         $this->compileWheres();
         $result = $this->query->update([
             $column => r\row($column)->difference([$value])
-        ])->run()->toNative();
+        ])->run();
 
         return (0 == (int) $result['errors']);
     }
@@ -327,7 +327,7 @@ class Builder extends QueryBuilder
         $this->compileWheres();
         $result = $this->query->min($column)
             ->getField($column)->rDefault(null)
-            ->run()->toNative();
+            ->run();
         return $result;
     }
     /**
@@ -341,7 +341,7 @@ class Builder extends QueryBuilder
         $this->compileWheres();
         $result = $this->query->max($column)
             ->getField($column)->rDefault(null)
-            ->run()->toNative();
+            ->run();
         return $result;
     }
 
@@ -355,7 +355,7 @@ class Builder extends QueryBuilder
     {
         $this->compileWheres();
         $result = $this->query->avg($column)
-            ->rDefault(null)->run()->toNative();
+            ->rDefault(null)->run();
         return $result;
     }
 
@@ -372,7 +372,7 @@ class Builder extends QueryBuilder
         $this->compileWheres();
         $result = $this->query->replace(function($doc) use ($columns) {
             return $doc->without($columns);
-        })->run()->toNative();
+        })->run();
 
         return (0 == (int) $result['errors']);
     }


### PR DESCRIPTION
Starting with PHP-RQL 2.0, toNative() is no longer necessary. Instead run() and cursors will return native objects directly (similar to the official drivers).

@see https://github.com/danielmewes/php-rql/issues/77
