### PR TITLE
Removing toNative()

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -44,7 +44,7 @@ class Query {
 
         if (in_array($method, $autoRun))
         {
-            return $this->run($query)->toNative();
+            return $this->run($query);
         }
 
         $this->query = $query;


### PR DESCRIPTION
Starting with PHP-RQL 2.0, toNative() is no longer necessary. Instead run() and cursors will return native objects directly (similar to the official drivers).

@see https://github.com/danielmewes/php-rql/issues/77
