### PR TITLE
Updating model and test to fix laravel timestamps

### DIFF
--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -2,7 +2,6 @@
 
 namespace duxet\Rethinkdb\Eloquent;
 
-use Carbon\Carbon;
 use DateTime;
 use duxet\Rethinkdb\Eloquent\Relations\BelongsTo;
 use duxet\Rethinkdb\Query\Builder as QueryBuilder;
@@ -32,7 +31,7 @@ class Model extends \Illuminate\Database\Eloquent\Model
     }
 
     /**
-     * Ensure Timestamps are returned in DateTime
+     * Ensure Timestamps are returned in DateTime.
      *
      * @param DateTime $value
      *
@@ -47,7 +46,7 @@ class Model extends \Illuminate\Database\Eloquent\Model
     }
 
     /**
-     * Retain DateTime format for storage
+     * Retain DateTime format for storage.
      *
      * @param  \DateTime  $value
      * @return string

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -32,15 +32,39 @@ class Model extends \Illuminate\Database\Eloquent\Model
     }
 
     /**
-     * Return DateTime object as Carbon instance.
+     * Ensure Timestamps are returned in DateTime
      *
      * @param DateTime $value
      *
-     * @return \Carbon\Carbon
+     * @return \DateTime
      */
     protected function asDateTime($value)
     {
-        return Carbon::instance($value);
+        if ($value instanceof DateTime) {
+            return $value;
+        }
+        return new DateTime($value);
+    }
+
+    /**
+     * Retain DateTime format for storage
+     *
+     * @param  \DateTime  $value
+     * @return string
+     */
+    public function fromDateTime($value)
+    {
+        return $this->asDateTime($value);
+    }
+
+    /**
+     * Get a fresh timestamp for the model.
+     *
+     * @return \DateTime
+     */
+    public function freshTimestamp()
+    {
+        return new DateTime();
     }
 
     /**

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -33,7 +33,7 @@ class Model extends \Illuminate\Database\Eloquent\Model
     /**
      * Ensure Timestamps are returned in DateTime.
      *
-     * @param DateTime $value
+     * @param \DateTime $value
      *
      * @return \DateTime
      */
@@ -48,7 +48,7 @@ class Model extends \Illuminate\Database\Eloquent\Model
     /**
      * Retain DateTime format for storage.
      *
-     * @param  \DateTime  $value
+     * @param \DateTime $value
      * @return string
      */
     public function fromDateTime($value)

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -49,6 +49,7 @@ class Model extends \Illuminate\Database\Eloquent\Model
      * Retain DateTime format for storage.
      *
      * @param \DateTime $value
+     *
      * @return string
      */
     public function fromDateTime($value)

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -42,6 +42,7 @@ class Model extends \Illuminate\Database\Eloquent\Model
         if ($value instanceof DateTime) {
             return $value;
         }
+
         return new DateTime($value);
     }
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -154,7 +154,7 @@ class Builder extends QueryBuilder
         $this->compileWheres();
         $result = $this->query->insert($values);
 
-        return (0 == (int) $result['errors']);
+        return 0 == (int) $result['errors'];
     }
 
     /**
@@ -271,7 +271,7 @@ class Builder extends QueryBuilder
     {
         $result = $this->query->delete()->run();
 
-        return (0 == (int) $result['errors']);
+        return 0 == (int) $result['errors'];
     }
 
     /**
@@ -292,7 +292,7 @@ class Builder extends QueryBuilder
             $column => r\row($column)->{$operation}($value),
         ])->run();
 
-        return (0 == (int) $result['errors']);
+        return 0 == (int) $result['errors'];
     }
 
     /**
@@ -310,7 +310,7 @@ class Builder extends QueryBuilder
             $column => r\row($column)->difference([$value]),
         ])->run();
 
-        return (0 == (int) $result['errors']);
+        return 0 == (int) $result['errors'];
     }
 
     /**
@@ -377,6 +377,7 @@ class Builder extends QueryBuilder
 
         return $result;
     }
+
     /**
      * Retrieve the maximum value of a given column.
      *
@@ -428,7 +429,7 @@ class Builder extends QueryBuilder
             return $doc->without($columns);
         })->run();
 
-        return (0 == (int) $result['errors']);
+        return 0 == (int) $result['errors'];
     }
 
     /**

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -218,4 +218,15 @@ class QueryTest extends TestCase
             })->get();
         $this->assertEquals(2, count($users));
     }
+
+    public function testCreatedAt()
+    {
+        $users = User::orderBy('created_at', 'desc')->take(10)->get();
+        $prev_date = new \DateTime();
+        foreach ($users as $user) {
+            $this->assertEquals('DateTime', get_class($user->created_at));
+            $this->assertLessThanOrEqual($prev_date, $user->created_at);
+            $prev_date = $user->created_at;
+        }
+    }
 }

--- a/tests/models/Client.php
+++ b/tests/models/Client.php
@@ -11,10 +11,12 @@ class Client extends Model
     {
         return $this->belongsToMany('User');
     }
+
     public function photo()
     {
         return $this->morphOne('Photo', 'imageable');
     }
+
     public function addresses()
     {
         return $this->hasMany('Address', 'data.address_id', 'data.client_id');


### PR DESCRIPTION
As mentioned in #19 I had an issue with timestamps being stored as strings instead of Reql date objects.

Upon further inspection, I noticed that the PHP driver for Rethink requires a DateTime object to be passed in for timestamps to be saved properly, but because of the way Eloquent normally handles these (it converts Carbon objects to strings before saving), the PHP driver was saving timestamps as strings.

This pull request addresses the issue and test verifies it. Thanks!
