### PR TITLE
made the changes so that it will be compatable with 5.2

### DIFF
--- a/src/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Console/Migrations/MigrateMakeCommand.php
@@ -22,7 +22,7 @@ class MigrateMakeCommand extends LaravelMigration
      * Create a new migration install command instance.
      *
      * @param duxet\Rethinkdb\Migrations\MigrationCreator $creator
-     * @param \Illuminate\Support\Composer             $composer
+     * @param \Illuminate\Support\Composer                $composer
      *
      * @return void
      */

--- a/src/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Console/Migrations/MigrateMakeCommand.php
@@ -4,7 +4,7 @@ namespace duxet\Rethinkdb\Console\Migrations;
 
 use duxet\Rethinkdb\Migrations\MigrationCreator;
 use Illuminate\Database\Console\Migrations\MigrateMakeCommand as LaravelMigration;
-use Illuminate\Foundation\Composer;
+use Illuminate\Support\Composer;
 
 class MigrateMakeCommand extends LaravelMigration
 {
@@ -22,7 +22,7 @@ class MigrateMakeCommand extends LaravelMigration
      * Create a new migration install command instance.
      *
      * @param duxet\Rethinkdb\Migrations\MigrationCreator $creator
-     * @param \Illuminate\Foundation\Composer             $composer
+     * @param \Illuminate\Support\Composer             $composer
      *
      * @return void
      */


### PR DESCRIPTION
Laravel has changed the Composer Class namespace, so this will fix it

"The Illuminate\Foundation\Composer class has been moved to Illuminate\Support\Composer."

I wish guys you can create a new branch and merge it since we need to keep it working for anyone using Laravel 5.1.x
