### PR TITLE
Addition to readme indicating update to User model

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,24 @@ You can easily create a model class using the following command which will creat
 
 Please note that you can use the same options that you use in `make:model` with `make:rethink-model`, as its based on laravel `make:model`
 
-Be aware that any model classes that Laravel generates itself will need to be updated manually, otherwise seeding will not work properly.  For example, the User model extends `Illuminate\Foundation\Auth\User`, which extends `Illuminate\Database\Eloquent\Model` and further implements several interfaces and associated traits that if their functionality is required will need to be added to the User model.  For example, it your User model might look like this:
+## Example of Laravel News Model Class
+
+This is an example of how the laravel model class has become
+
+	<?php
+
+	namespace App;
+
+	use \duxet\Rethinkdb\Eloquent\Model;
+
+	class News extends Model
+	{
+	    //
+	}
+
+## Example of Updating Laravel User Model Class
+
+Be aware that any model that Laravel generates during its initial installation will need to be updated manually in order for them to work properly.  For example, the User model extends `Illuminate\Foundation\Auth\User`, which further extends `Illuminate\Database\Eloquent\Model` instead of `\duxet\Rethinkdb\Eloquent\Model;`. The import `Illuminate\Foundation\Auth\User` needs to be removed from the User model and replaced with `\duxet\Rethinkdb\Eloquent\Model;`, and any interfaces and associated traits implemented in `Illuminate\Foundation\Auth\User` that are required will need to be ported to the User model.
 
 ```
 use Illuminate\Auth\Authenticatable;
@@ -144,20 +161,3 @@ class User extends Model implements
     //
 }
 ```
-
-
-## Example of Laravel News Model Class
-
-This is an example of how the laravel model class has become
-
-	<?php
-
-	namespace App;
-
-	use \duxet\Rethinkdb\Eloquent\Model;
-
-	class News extends Model
-	{
-	    //
-	}
-

--- a/README.md
+++ b/README.md
@@ -138,9 +138,13 @@ This is an example of how the laravel model class has become
 	    //
 	}
 
-## Example of Updating Laravel User Model Class
+## Update a Model Class
 
 Be aware that any model that Laravel generates during its initial installation will need to be updated manually in order for them to work properly.  For example, the User model extends `Illuminate\Foundation\Auth\User`, which further extends `Illuminate\Database\Eloquent\Model` instead of `\duxet\Rethinkdb\Eloquent\Model;`. The import `Illuminate\Foundation\Auth\User` needs to be removed from the User model and replaced with `\duxet\Rethinkdb\Eloquent\Model;`, and any interfaces and associated traits implemented in `Illuminate\Foundation\Auth\User` that are required will need to be ported to the User model.
+
+## Example of Updating Laravel User Model Class
+
+This is an example of how the laravel User model class has become
 
 ```
 use Illuminate\Auth\Authenticatable;

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ This is an example of how the laravel model class has become
 
 Be aware that any model that Laravel generates during its initial installation will need to be updated manually in order for them to work properly.  For example, the User model extends `Illuminate\Foundation\Auth\User`, which further extends `Illuminate\Database\Eloquent\Model` instead of `\duxet\Rethinkdb\Eloquent\Model;`. The import `Illuminate\Foundation\Auth\User` needs to be removed from the User model and replaced with `\duxet\Rethinkdb\Eloquent\Model;`, and any interfaces and associated traits implemented in `Illuminate\Foundation\Auth\User` that are required will need to be ported to the User model.
 
-## Example of Updating Laravel User Model Class
+## Example of Laravel User Model Class
 
 This is an example of how the laravel User model class has become
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,29 @@ You can easily create a model class using the following command which will creat
 
 Please note that you can use the same options that you use in `make:model` with `make:rethink-model`, as its based on laravel `make:model`
 
+Be aware that any model classes that Laravel generates itself will need to be updated manually, otherwise seeding will not work properly.  For example, the User model extends `Illuminate\Foundation\Auth\User`, which extends `Illuminate\Database\Eloquent\Model` and further implements several interfaces and associated traits that if their functionality is required will need to be added to the User model.  For example, it your User model might look like this:
+
+```
+use Illuminate\Auth\Authenticatable;
+use \duxet\Rethinkdb\Eloquent\Model;
+use Illuminate\Auth\Passwords\CanResetPassword;
+use Illuminate\Foundation\Auth\Access\Authorizable;
+use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
+use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
+use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
+
+class User extends Model implements
+    AuthenticatableContract,
+    AuthorizableContract,
+    CanResetPasswordContract
+{
+    use Authenticatable, Authorizable, CanResetPassword;
+    
+    //
+}
+```
+
+
 ## Example of Laravel News Model Class
 
 This is an example of how the laravel model class has become


### PR DESCRIPTION
The readme didn't point out a small pitfall that could occur if a installation generated model (like the User model) isn't updated manually, which can cause a bit of frustration and wasted time rummaging through logs trying to figure out why getPdo is null during seeding, etc.  This PR just points it out so it isn't glazed over.
