### PR TITLE
Update to readme indicating Schema API isn't fully implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ You can easily create a migration file using the following command which will cr
 
 Please note that you can use the same options that you use in `make:migration` with `make:rethink-migration`, as its based on laravel `make:migration`
 
+Be aware that Laravel Schema API is not fully implemented.  For example, ID columns using increments will not be auto-incremented unsigned integers, and will instead be a UUID unless explicitly set.  The easiest solution is to maintain UUID use within RethinkDB, turn off incremental IDs in Laravel, and finally implement UUID use in Laravel.
+
 
 ## Running The Migrations
 


### PR DESCRIPTION
Attempts to authenticate appeared to be failing as authenticated routes were inaccessible, but it turned out the user was being authenticated, and the ID column was actually not an auto-incremented unsigned integer as it would be using Laravel + MySQL.  Instead it was a truncated parsed integer from the front of a UUID.  Added this to the readme so others aren't in the dark thinking the package doesn't work, but instead need to implement UUID in Laravel, or implement the increments method for RethinkDB to be set explicitly to an unsigned integer index.
