### PR TITLE
Turned off incremental ID and remarked on use of UUID in migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,7 @@ You can easily create a migration file using the following command which will cr
 
 Please note that you can use the same options that you use in `make:migration` with `make:rethink-migration`, as its based on laravel `make:migration`
 
-Be aware that Laravel Schema API is not fully implemented.  For example, ID columns using increments will not be auto-incremented unsigned integers, and will instead be a UUID unless explicitly set.  The easiest solution is to maintain UUID use within RethinkDB, turn off incremental IDs in Laravel, and finally implement UUID use in Laravel.
-
+RethinkDB doesn't support auto-incrementing IDs, and instead uses a standards-compliant implementation of UUID (universally unique identifier), making implementing UUIDs unnecessary within Laravel, even if used outside the auto-generated UUID for ID columns by using the [ReQL API](https://www.rethinkdb.com/api/javascript/uuid/). Incrementing has been turned off in `duxet\Rethinkdb\Eloquent\Model` to support the use of UUIDs, and instead of using `$table->increments('id');` for primary keys in your migrations you can use `$table->uuid('id');`.
 
 ## Running The Migrations
 
@@ -94,7 +93,7 @@ This is an example of how the laravel Users Migration file has become
 	    public function up()
 	    {
 	        Schema::create('users', function (Blueprint $table) {
-	            $table->increments('id');
+	            $table->uuid('id');
 	            $table->string('name');
 	            $table->string('email')->unique();
 	            $table->string('password', 60);

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -11,6 +11,13 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 class Model extends \Illuminate\Database\Eloquent\Model
 {
     /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var
+     */
+    public $incrementing = false;
+    
+    /**
      * Get the format for database stored dates.
      *
      * @return string


### PR DESCRIPTION
Incremental IDs will always have to be turned off as RethinkDB doesn't support them, and they attempt to cast the UUID to a PHP integer data type, which truncates the UUID.  So updated in `Rethinkdb\Eloquent\Model`, and updated readme indicating changes, and the use of Laravel Schema's UUID migration method instead of increments.
