### PR TITLE
Convert all ArrayObjects to native arrays [Trying to solve broken down migrations]

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -66,6 +66,21 @@ class Query
         $time = $this->connection->getElapsedTime($start);
         $this->connection->logQuery($query, [], $time);
 
-        return $result;
+        return $this->nativeArray($result);
+    }
+
+    private function nativeArray($val)
+    {
+        if (is_array($val)) {
+            foreach ($val as $k => $v) {
+                $val[$k] = $this->nativeArray($v);
+            }
+
+            return $val;
+        } elseif (is_object($val) && $val instanceof \ArrayObject) {
+            return $val->getArrayCopy();
+        } else {
+            return $val;
+        }
     }
 }


### PR DESCRIPTION
Hey,

Migration resets/rollbacks don't seem to work with this library, the suspect parts in Larvel are  [`Migrator->rollback`](https://github.com/laravel/framework/blob/5.2/src/Illuminate/Database/Migrations/Migrator.php#L163-L186) and [`Migrator->runDown`](https://github.com/laravel/framework/blob/5.2/src/Illuminate/Database/Migrations/Migrator.php#L220-L241)

As you can see, `rollback` casts each migration to an object before passing to `runDown`, which then tries to access the object property. As php-rql returns `ArrayObject`'s, this access fails.

This change is a bit hacky but converts `ArrayObjects` to native arrays!

Questions:
- Has anybody else found down/rollback migrations to be broken?
- ~~Any idea why `ArrayObject` is used? (I have an issue open with php-rql)~~
- ~~Is there a better approach?~~

Thanks!
