### PR TITLE
Use Carbon for DateTimes and fix Model serialisation

### DIFF
--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -1,0 +1,80 @@
+<?php
+
+class ModelTest extends TestCase
+{
+    public function testToArray()
+    {
+        $item = Item::create(['name' => 'fork', 'type' => 'sharp']);
+        $array = $item->toArray();
+        $keys = array_keys($array);
+        sort($keys);
+        $this->assertEquals(['created_at', 'id', 'name', 'type', 'updated_at'], $keys);
+        $this->assertTrue(is_string($array['created_at']));
+        $this->assertTrue(is_string($array['updated_at']));
+        $this->assertTrue(is_string($array['id']));
+    }
+
+    public function testDates()
+    {
+        $birthday = new DateTime('1980/1/1');
+        $user = User::create(['name' => 'John Doe', 'birthday' => $birthday]);
+        $this->assertInstanceOf('Carbon\Carbon', $user->birthday);
+
+        $check = User::find($user->id);
+        $this->assertInstanceOf('Carbon\Carbon', $check->birthday);
+        $this->assertEquals($user->birthday, $check->birthday);
+
+        // NOTE: This is only supported in Laravel >= 5.1, prior to this eloquent just casts
+        //       the date to a string, ignoring any custom $dateFormat
+        // $user = User::where('birthday', '>', new DateTime('1975/1/1'))->first();
+        // $this->assertEquals('John Doe', $user->name);
+        // // test custom date format for json output
+        // $json = $user->toArray();
+        // $this->assertEquals($user->birthday->format('l jS \of F Y h:i:s A'), $json['birthday']);
+        // $this->assertEquals($user->created_at->format('l jS \of F Y h:i:s A'), $json['created_at']);
+
+        // test default date format for json output
+        $item = Item::create(['name' => 'sword']);
+        $json = $item->toArray();
+        $this->assertEquals($item->created_at->format('Y-m-d H:i:s'), $json['created_at']);
+
+        $user = User::create(['name' => 'Jane Doe', 'birthday' => time()]);
+        $this->assertInstanceOf('Carbon\Carbon', $user->birthday);
+
+        $user = User::create(['name' => 'Jane Doe', 'birthday' => 'Monday 8th of August 2005 03:12:46 PM']);
+        $this->assertInstanceOf('Carbon\Carbon', $user->birthday);
+
+        $user = User::create(['name' => 'Jane Doe', 'birthday' => '2005-08-08']);
+        $this->assertInstanceOf('Carbon\Carbon', $user->birthday);
+
+        // TODO: This requires this library to support subdocuments
+        // $user = User::create(['name' => 'Jane Doe', 'entry' => ['date' => '2005-08-08']]);
+        // $this->assertInstanceOf('Carbon\Carbon', $user->getAttribute('entry.date'));
+        // $user->setAttribute('entry.date', new DateTime);
+        // $this->assertInstanceOf('Carbon\Carbon', $user->getAttribute('entry.date'));
+        // $data = $user->toArray();
+        // $this->assertNotInstanceOf('MongoDB\BSON\UTCDateTime', $data['entry']['date']);
+        // $this->assertEquals((string) $user->getAttribute('entry.date')->format('Y-m-d H:i:s'), $data['entry']['date']);
+    }
+
+    public function testGetDirtyDates()
+    {
+        $user = new User();
+        $user->setRawAttributes(['name' => 'John Doe', 'birthday' => new DateTime('19 august 1989')], true);
+        $this->assertEmpty($user->getDirty());
+        $user->birthday = new DateTime('19 august 1989');
+        $this->assertEmpty($user->getDirty());
+    }
+
+    public function testNativeDatePersistance()
+    {
+        $item = Item::create(['name' => 'spoon', 'type' => 'round']);
+        $connection = DB::connection()->getConnection();
+        $raw = r\table('items')->get($item->id)->run($connection, ['timeFormat' => 'raw']);
+
+        $this->assertArrayHasKey('$reql_type$', $raw['created_at']);
+        $this->assertEquals('TIME', $raw['created_at']['$reql_type$']);
+        $this->assertEquals($item->created_at->getTimestamp(), $raw['created_at']['epoch_time']);
+        $this->assertEquals('+00:00', $raw['created_at']['timezone']);
+    }
+}

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -218,15 +218,4 @@ class QueryTest extends TestCase
             })->get();
         $this->assertEquals(2, count($users));
     }
-
-    public function testCreatedAt()
-    {
-        $users = User::orderBy('created_at', 'desc')->take(10)->get();
-        $prev_date = new \DateTime();
-        foreach ($users as $user) {
-            $this->assertEquals('DateTime', get_class($user->created_at));
-            $this->assertLessThanOrEqual($prev_date, $user->created_at);
-            $prev_date = $user->created_at;
-        }
-    }
 }

--- a/tests/models/User.php
+++ b/tests/models/User.php
@@ -6,6 +6,7 @@ class User extends Model
 {
     protected $dates = ['birthday', 'entry.date'];
     protected static $unguarded = true;
+    protected $dateFormat = 'l jS \of F Y h:i:s A';
 
     public function books()
     {


### PR DESCRIPTION
The changes introduced in #19 allowed dates to be stored as natively however the method overrides break model serialisation, such as json encoding.
This change maintains native date storage whilst preserving the use of Carbon in models. It also adds more comprehensive testing of date storage, conversion and formatting.
It also fixes dirty date recognition.

Changes are largely inspired by laravel-mongodb, most of the tests now in `ModelTest` were failing before this change.

I've removed the `testCreatedAt` in favour of the more explicit testing in `ModelTest`
