### PR TITLE
Fix for make:model Error

### DIFF
--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -16,7 +16,7 @@ class Model extends \Illuminate\Database\Eloquent\Model
      *
      * @return string
      */
-    protected function getDateFormat()
+    public function getDateFormat()
     {
         return $this->dateFormat ?: 'Y-m-d H:i:s';
     }


### PR DESCRIPTION
PHP Fatal error:  Access level to duxet\Rethinkdb\Eloquent\Model::getDateFormat() must be public (as in class Illuminate\Database\Eloquent\Model)