### PR TITLE
Fix Undefined property: duxet\Rethinkdb\Eloquent\Relations\BelongsTo:…

### DIFF
--- a/src/Eloquent/Relations/BelongsTo.php
+++ b/src/Eloquent/Relations/BelongsTo.php
@@ -4,6 +4,7 @@ namespace duxet\Rethinkdb\Eloquent\Relations;
 
 class BelongsTo extends \Illuminate\Database\Eloquent\Relations\BelongsTo
 {
+    protected $otherKey = 'id';
     /**
      * Set the base constraints on the relation query.
      *


### PR DESCRIPTION
…:$otherKey

if Eloquent Relation BelongsTo was using without specifying the otherKey Parameter it Produces
Undefined property: duxet\Rethinkdb\Eloquent\Relations\BelongsTo::$otherKey