### PR TITLE
Fix orchestra/testbench 3.0.x-dev requires laravel/framework 5.0.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "psr/log": "1.0.0",
-        "orchestra/testbench": "3.0.*",
+        "orchestra/testbench": "3.7.*",
         "codeclimate/php-test-reporter": "0.1.*@dev",
         "mockery/mockery": "0.9.*@dev",
         "phpunit/phpunit": "~4.0"


### PR DESCRIPTION
Travis CI Test Gives Error:
orchestra/testbench 3.0.x-dev requires laravel/framework 5.0.*

When test on any version higher than 7.1