### PR TITLE
Add auto-discovery for Laravel 5.5+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,12 @@
         "mockery/mockery": "0.9.*@dev",
         "phpunit/phpunit": "~4.0"
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "extra": {
+        "laravel": {
+            "providers": [
+                "duxet\\Rethinkdb\\RethinkdbServiceProvider"
+            ]
+        }
+    }
 }


### PR DESCRIPTION
Add service provider to composer.json to enable auto-discovery for Laravel 5.5+