### PR TITLE
Update Model with $keyType = 'string' property

### DIFF
--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -12,6 +12,15 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 class Model extends \Illuminate\Database\Eloquent\Model
 {
     /**
+     * The "type" of the auto-incrementing ID.
+     * Setting to 'string' prevents Laravel from casting non-integer IDs
+     * to numeric ones. Very helpful with inverted relations.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
+    
+    /**
      * Get the format for database stored dates.
      *
      * @return string


### PR DESCRIPTION
Use of $keyType property, set to 'string' (instead of default, Laravel's int), prevents Laravel from casting non-integer IDs to numeric ones. Since RethinkDB uses UUIDs instead of ints, thought it might be good to change default $keyType directly in base Model class.